### PR TITLE
AENG-1114 update calls stream with new attributes

### DIFF
--- a/tap_gong/streams/calls.py
+++ b/tap_gong/streams/calls.py
@@ -136,19 +136,39 @@ class CallsStream(GongStream):
                     ),
                 ),
                 th.Property(
-                    "pointsOfInterest",
-                    th.ObjectType(
-                        th.Property(
-                            "actionItems",
-                            th.ArrayType(
-                                th.ObjectType(
-                                    th.Property("snippetStartTime", th.NumberType),
-                                    th.Property("snippetEndTime", th.NumberType),
-                                    th.Property("speakerID", th.StringType),
-                                    th.Property("snippet", th.StringType),
-                                )
+                    "outline",
+                    th.ArrayType(
+                        th.ObjectType(
+                            th.Property("section", th.StringType),
+                            th.Property("startTime", th.NumberType),
+                            th.Property("duration", th.NumberType),
+                            th.Property(
+                                "items",
+                                th.ArrayType(
+                                    th.ObjectType(
+                                        th.Property("text", th.StringType),
+                                        th.Property("startTime", th.NumberType),
+                                    )
+                                ),
                             ),
-                        ),
+                        )
+                    ),
+                ),
+                th.Property(
+                    "highlights",
+                    th.ArrayType(
+                        th.ObjectType(
+                            th.Property("title", th.StringType),
+                            th.Property(
+                                "items",
+                                th.ArrayType(
+                                    th.ObjectType(
+                                        th.Property("text", th.StringType),
+                                        th.Property("startTimes", th.ArrayType(th.NumberType)),
+                                    )
+                                ),
+                            ),
+                        )
                     ),
                 ),
             ),
@@ -250,7 +270,8 @@ class CallsStream(GongStream):
                 "exposedFields": {
                     "collaboration": {"publicComments": True},
                     "content": {
-                        "pointsOfInterest": True,
+                        "highlights": True,
+                        "outline": True,
                         "structure": True,
                         "topics": True,
                         "trackers": True,


### PR DESCRIPTION
This PR updates the `calls` stream in our fork of the Gong tap to make available a couple of new fields on the endpoint [per their API documentation:](https://gong.app.gong.io/settings/api/documentation#post-/v2/calls/extensive)

- Adds `content.outline`
- Adds `content.highlights`
- Removes `content.pointsOfInterest`

The two additions are AI-based summarizations provided by Gong.  Having these available is convenient because then we don't have to generate those AI summaries ourselves, and we'll use data that's consistent with what's available in Gong's UI.  `pointsOfInterest` was deprecated, and I confirmed that none of the calls that we replicate to the warehouse actually bring in this field anymore (of course, it's no longer available).

After this PR is merged, I'll put up a second PR in thinkific/data-meltano-ingestion to use our fork of this repository, and rebuild the Cloud Run container image.